### PR TITLE
Fixed targetBotDialog pointing to old name

### DIFF
--- a/force-app/main/default/bots/Mascot/v1.botVersion-meta.xml
+++ b/force-app/main/default/bots/Mascot/v1.botVersion-meta.xml
@@ -1723,7 +1723,7 @@ Please reach out to an Admissions Counsellor.</message>
             <botSteps>
                 <botNavigation>
                     <botNavigationLinks>
-                        <targetBotDialog>Speak_with_an_Admissions_Counselor</targetBotDialog>
+                        <targetBotDialog>Contact_an_Admissions_Counselor</targetBotDialog>
                     </botNavigationLinks>
                     <type>Redirect</type>
                 </botNavigation>


### PR DESCRIPTION

# Critical Changes

# Changes
updated botVersion pointing to a botDialog that was renamed
# Issues Closed
