### PR TITLE
Alastair's Tasks

### DIFF
--- a/force-app/main/default/bots/Mascot/v1.botVersion-meta.xml
+++ b/force-app/main/default/bots/Mascot/v1.botVersion-meta.xml
@@ -379,7 +379,7 @@
         <botDialogGroup>Main_Menu_Options</botDialogGroup>
         <botSteps>
             <botMessages>
-                <message>Here&apos;s how you can connect with someone from the Admissions Team</message>
+                <message>Let’s get you in touch with an Admissions Counselor</message>
             </botMessages>
             <type>Message</type>
         </botSteps>


### PR DESCRIPTION
# Critical Changes

Two changes in the Bot dialogs.
1. connect to a counselor message is Here's how you can connect with someone from the Admissions Team
2. remove Multiple Applications flow (was written out), now points to Admission Counsellor 
3. fix minor grammar error

# Changes

# Issues Closed
[W-8951103](https://gus.lightning.force.com/lightning/r/ADM_Sprint__c/a0lB0000002adLkIAI/view) Change Connect with Counselor dialog
W-8968304[W-8968304](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008x7MpIAI/view)  Remove Multiple Applications Path from MVP



